### PR TITLE
Remove "restart" from the docker compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,6 @@ services:
   roscore:
     build: ./roscore/
     command: stdbuf -o L roscore
-    restart: always
 
   mavros:
     build: ./mavros/
@@ -11,7 +10,6 @@ services:
       - roscore
     environment:
       - "ROS_MASTER_URI=http://roscore:11311"
-    restart: always
 
   arm:
     build: .


### PR DESCRIPTION
Some of the services in this docker compose file where running in the background and this was unexpected. We think this could have caused some issues in the field where our software wouldn't work.